### PR TITLE
fix: resolve ES Module import issues for jose library

### DIFF
--- a/scripts/generate-token.js
+++ b/scripts/generate-token.js
@@ -11,7 +11,6 @@
  *   node scripts/generate-token.js --payload '{"sub":"user123","role":"admin"}'
  */
 
-const { SignJWT } = require('jose');
 require('dotenv/config');
 
 async function generateToken() {
@@ -61,6 +60,7 @@ async function generateToken() {
         );
 
         // Generate token
+        const { SignJWT } = await import('jose');
         const token = await new SignJWT(payload)
             .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
             .sign(key);

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -2,7 +2,6 @@ import { Message, Chat, MessageMedia } from 'whatsapp-web.js';
 import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment, ChatMessage } from '../types';
 import axios from 'axios';
-import { SignJWT } from 'jose';
 
 export class MessageHandler {
     private messageQueue: { [senderNumber: string]: Array<{ message: Message; timestamp: number }> } = {};
@@ -642,6 +641,8 @@ export class MessageHandler {
     }
 
     private async signJWT(payload: any, secret: string): Promise<string> {
+        const { SignJWT } = await import('jose');
+        
         const key = await crypto.subtle.importKey(
             'raw',
             new TextEncoder().encode(secret),

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from 'express';
-import { jwtVerify } from 'jose';
 import { Environment } from '../types';
 
 export interface AuthenticatedRequest extends Request {
@@ -65,6 +64,7 @@ export class AuthMiddleware {
 
             // Verify JWT token
             try {
+                const { jwtVerify } = await import('jose');
                 const key = await this.getJWTKey();
                 const { payload } = await jwtVerify(token, key);
                 

--- a/src/utils/jwt-generator.ts
+++ b/src/utils/jwt-generator.ts
@@ -1,4 +1,3 @@
-import { SignJWT } from 'jose';
 import { Environment } from '../types';
 
 export class JWTGenerator {
@@ -22,6 +21,7 @@ export class JWTGenerator {
             ...payload
         };
 
+        const { SignJWT } = await import('jose');
         const key = await this.getJWTKey();
         
         const jwt = await new SignJWT(defaultPayload)


### PR DESCRIPTION
- Replace static imports with dynamic imports for jose library
- Fix ERR_REQUIRE_ESM error in production deployment
- Update message-handler.ts to use dynamic import for SignJWT
- Update auth.middleware.ts to use dynamic import for jwtVerify
- Update jwt-generator.ts to use dynamic import for SignJWT
- Update generate-token.js script to use dynamic import
- Maintain full JWT functionality while fixing CommonJS compatibility

This resolves the deployment error:
Error [ERR_REQUIRE_ESM]: require() of ES Module /usr/src/app/node_modules/jose/dist/webapi/index.js not supported

All JWT authentication features remain fully functional.