### PR TITLE
fix: resolve remaining jose import in api.controller.ts

### DIFF
--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -3,7 +3,6 @@ import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment } from '../types';
 import mongoose from 'mongoose';
 import axios from 'axios';
-import { SignJWT } from 'jose';
 
 export class ApiController {
     constructor(
@@ -287,6 +286,7 @@ export class ApiController {
                 ['sign', 'verify']
             );
 
+            const { SignJWT } = await import('jose');
             const jwt = await new SignJWT(jwtPayload)
                 .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
                 .sign(key);


### PR DESCRIPTION
- Remove static import of SignJWT from jose library
- Replace with dynamic import to fix ERR_REQUIRE_ESM error
- Complete the ES Module compatibility fix for production deployment
- All jose library imports now use dynamic imports

This fixes the remaining deployment error:
Error [ERR_REQUIRE_ESM]: require() of ES Module from /usr/src/app/dist/controllers/api.controller.js

Application now fully compatible with CommonJS environment while using ES Module jose library.