### PR TITLE
fix: resolve missing CSS file error in deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,9 @@ RUN npm install --only=production && npm cache clean --force
 # Copy built application from builder stage
 COPY --from=builder /usr/src/app/dist ./dist
 
+# Copy public assets (CSS, etc.)
+COPY public/ ./public/
+
 # Copy environment file if exists
 COPY .env* ./
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -78,7 +78,13 @@ export class WhatsAppBotApp {
 
     private setupRoutes(): void {
         // Setup Swagger documentation with Monokai theme
-        const monokaiCSS = fs.readFileSync('public/css/theme-monokai.css', 'utf8');
+        let monokaiCSS = '';
+        try {
+            monokaiCSS = fs.readFileSync('public/css/theme-monokai.css', 'utf8');
+        } catch (error) {
+            console.warn('⚠️ Monokai CSS file not found, using default Swagger theme');
+        }
+        
         this.app.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
             explorer: true,
             customCss: `


### PR DESCRIPTION
- Add public/ directory to Dockerfile to include CSS assets
- Add error handling for missing theme-monokai.css file
- Application now gracefully handles missing CSS files
- Swagger documentation works with or without custom theme

This fixes the deployment error:
Error: ENOENT: no such file or directory, open 'public/css/theme-monokai.css'

The application will now start successfully even if CSS files are missing, falling back to default Swagger theme while maintaining full functionality.