### PR TITLE
fix: resolve JWT key format issues for jose library compatibility

### DIFF
--- a/scripts/generate-token.js
+++ b/scripts/generate-token.js
@@ -50,17 +50,12 @@ async function generateToken() {
         // Merge with custom payload
         const payload = { ...defaultPayload, ...customPayload };
 
-        // Generate JWT key
-        const key = await crypto.subtle.importKey(
-            'raw',
-            new TextEncoder().encode(jwtSecret),
-            { name: 'HMAC', hash: 'SHA-256' },
-            false,
-            ['sign']
-        );
+        // Generate JWT key using jose library
+        const jose = await import('jose');
+        const key = new TextEncoder().encode(jwtSecret);
 
         // Generate token
-        const { SignJWT } = await import('jose');
+        const { SignJWT } = jose;
         const token = await new SignJWT(payload)
             .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
             .sign(key);

--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -3,7 +3,8 @@ import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment } from '../types';
 import mongoose from 'mongoose';
 import axios from 'axios';
-import { getSignJWT } from '../utils/jose-import';
+import { getSignJWT, getJoseModule } from '../utils/jose-import';
+import crypto from 'crypto';
 
 export class ApiController {
     constructor(
@@ -278,14 +279,8 @@ export class ApiController {
                 exp: Math.floor(Date.now() / 1000) + (60 * 60), // 1 hour expiration
             };
 
-            // Sign JWT with agent data
-            const key = await crypto.subtle.importKey(
-                'raw',
-                new TextEncoder().encode(jwtSecret),
-                { name: 'HMAC', hash: 'SHA-256' },
-                false,
-                ['sign', 'verify']
-            );
+            // Sign JWT with agent data using jose library
+            const key = new TextEncoder().encode(jwtSecret);
 
             const SignJWT = await getSignJWT();
             const jwt = await new SignJWT(jwtPayload)

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -2,7 +2,8 @@ import { Message, Chat, MessageMedia } from 'whatsapp-web.js';
 import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment, ChatMessage } from '../types';
 import axios from 'axios';
-import { getSignJWT } from '../utils/jose-import';
+import { getSignJWT, getJoseModule } from '../utils/jose-import';
+import crypto from 'crypto';
 
 export class MessageHandler {
     private messageQueue: { [senderNumber: string]: Array<{ message: Message; timestamp: number }> } = {};
@@ -643,14 +644,10 @@ export class MessageHandler {
 
     private async signJWT(payload: any, secret: string): Promise<string> {
         const SignJWT = await getSignJWT();
+        const jose = await getJoseModule();
         
-        const key = await crypto.subtle.importKey(
-            'raw',
-            new TextEncoder().encode(secret),
-            { name: 'HMAC', hash: 'SHA-256' },
-            false,
-            ['sign', 'verify']
-        );
+        // Convert secret to Uint8Array for jose library
+        const key = new TextEncoder().encode(secret);
 
         return await new SignJWT(payload)
             .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Environment } from '../types';
-import { getJwtVerify } from '../utils/jose-import';
+import { getJwtVerify, getJoseModule } from '../utils/jose-import';
+import crypto from 'crypto';
 
 export interface AuthenticatedRequest extends Request {
     user?: {
@@ -120,13 +121,8 @@ export class AuthMiddleware {
      * Get JWT verification key
      */
     private async getJWTKey(): Promise<any> {
-        return await crypto.subtle.importKey(
-            'raw',
-            new TextEncoder().encode(this.jwtSecret),
-            { name: 'HMAC', hash: 'SHA-256' },
-            false,
-            ['verify']
-        );
+        // Convert secret to Uint8Array for jose library
+        return new TextEncoder().encode(this.jwtSecret);
     }
 }
 

--- a/src/utils/jwt-generator.ts
+++ b/src/utils/jwt-generator.ts
@@ -1,5 +1,6 @@
 import { Environment } from '../types';
-import { getSignJWT } from './jose-import';
+import { getSignJWT, getJoseModule } from './jose-import';
+import crypto from 'crypto';
 
 export class JWTGenerator {
     private jwtSecret: string;
@@ -47,13 +48,8 @@ export class JWTGenerator {
      * Get JWT signing key
      */
     private async getJWTKey(): Promise<any> {
-        return await crypto.subtle.importKey(
-            'raw',
-            new TextEncoder().encode(this.jwtSecret),
-            { name: 'HMAC', hash: 'SHA-256' },
-            false,
-            ['sign']
-        );
+        // Convert secret to Uint8Array for jose library
+        return new TextEncoder().encode(this.jwtSecret);
     }
 }
 


### PR DESCRIPTION
- Convert JWT secrets to Uint8Array format using TextEncoder
- Fix all JWT signing and verification across the codebase:
  * auth.middleware.ts - JWT verification
  * message-handler.ts - JWT signing
  * jwt-generator.ts - Token generation
  * api.controller.ts - API JWT creation
  * generate-token.js - Script token generation

- Ensure WA_JWT_SECRET from environment is used consistently
- Remove dependency on Web Crypto API (crypto.subtle)
- Use jose library's expected key format (Uint8Array)

This resolves the JWT verification errors:
- TypeError: Key for the HS256 algorithm must be one of type CryptoKey, KeyObject, JSON Web Key, or Uint8Array
- TypeError: jose.createSecretKey is not a function

All JWT authentication now works correctly in both local and production environments.