### PR TITLE
fix: replace jose library with jsonwebtoken for Node.js compatibility

### DIFF
--- a/scripts/generate-token.js
+++ b/scripts/generate-token.js
@@ -50,15 +50,9 @@ async function generateToken() {
         // Merge with custom payload
         const payload = { ...defaultPayload, ...customPayload };
 
-        // Generate JWT key using jose library
-        const jose = await import('jose');
-        const key = new TextEncoder().encode(jwtSecret);
-
-        // Generate token
-        const { SignJWT } = jose;
-        const token = await new SignJWT(payload)
-            .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
-            .sign(key);
+        // Generate token using jsonwebtoken
+        const jwt = require('jsonwebtoken');
+        const token = jwt.sign(payload, jwtSecret, { algorithm: 'HS256' });
 
         console.log('🔐 JWT Token Generated Successfully!');
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');

--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -3,8 +3,7 @@ import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment } from '../types';
 import mongoose from 'mongoose';
 import axios from 'axios';
-import { getSignJWT, getJoseModule } from '../utils/jose-import';
-import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 
 export class ApiController {
     constructor(
@@ -279,16 +278,11 @@ export class ApiController {
                 exp: Math.floor(Date.now() / 1000) + (60 * 60), // 1 hour expiration
             };
 
-            // Sign JWT with agent data using jose library
-            const key = new TextEncoder().encode(jwtSecret);
-
-            const SignJWT = await getSignJWT();
-            const jwt = await new SignJWT(jwtPayload)
-                .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
-                .sign(key);
+            // Sign JWT with agent data using jsonwebtoken
+            const token = jwt.sign(jwtPayload, jwtSecret, { algorithm: 'HS256' });
 
             console.log('🧪 JWT created for agent');
-            console.log('🧪 Generated JWT:', jwt);
+            console.log('🧪 Generated JWT:', token);
             console.log('🧪 JWT payload:', JSON.stringify(jwtPayload, null, 2));
 
             const payload = {
@@ -303,7 +297,7 @@ export class ApiController {
 
             const requestHeaders = {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${jwt}`,
+                'Authorization': `Bearer ${token}`,
                 'X-Agent-Code': agentCode,
                 'X-Agent-Status': 'active',
                 'X-Agent-Type': 'bot'

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -2,8 +2,7 @@ import { Message, Chat, MessageMedia } from 'whatsapp-web.js';
 import { WhatsAppService } from '../services/whatsapp.service';
 import { Environment, ChatMessage } from '../types';
 import axios from 'axios';
-import { getSignJWT, getJoseModule } from '../utils/jose-import';
-import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 
 export class MessageHandler {
     private messageQueue: { [senderNumber: string]: Array<{ message: Message; timestamp: number }> } = {};
@@ -643,15 +642,7 @@ export class MessageHandler {
     }
 
     private async signJWT(payload: any, secret: string): Promise<string> {
-        const SignJWT = await getSignJWT();
-        const jose = await getJoseModule();
-        
-        // Convert secret to Uint8Array for jose library
-        const key = new TextEncoder().encode(secret);
-
-        return await new SignJWT(payload)
-            .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
-            .sign(key);
+        return jwt.sign(payload, secret, { algorithm: 'HS256' });
     }
 
     public cleanup(): void {

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { Environment } from '../types';
-import { getJwtVerify, getJoseModule } from '../utils/jose-import';
-import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 
 export interface AuthenticatedRequest extends Request {
     user?: {
@@ -66,9 +65,7 @@ export class AuthMiddleware {
 
             // Verify JWT token
             try {
-                const jwtVerify = await getJwtVerify();
-                const key = await this.getJWTKey();
-                const { payload } = await jwtVerify(token, key);
+                const payload = jwt.verify(token, this.jwtSecret) as any;
                 
                 // Add user info to request
                 req.user = {
@@ -117,13 +114,6 @@ export class AuthMiddleware {
         }
     };
 
-    /**
-     * Get JWT verification key
-     */
-    private async getJWTKey(): Promise<any> {
-        // Convert secret to Uint8Array for jose library
-        return new TextEncoder().encode(this.jwtSecret);
-    }
 }
 
 /**

--- a/src/utils/jwt-generator.ts
+++ b/src/utils/jwt-generator.ts
@@ -1,6 +1,5 @@
 import { Environment } from '../types';
-import { getSignJWT, getJoseModule } from './jose-import';
-import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 
 export class JWTGenerator {
     private jwtSecret: string;
@@ -23,14 +22,7 @@ export class JWTGenerator {
             ...payload
         };
 
-        const SignJWT = await getSignJWT();
-        const key = await this.getJWTKey();
-        
-        const jwt = await new SignJWT(defaultPayload)
-            .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
-            .sign(key);
-
-        return jwt;
+        return jwt.sign(defaultPayload, this.jwtSecret, { algorithm: 'HS256' });
     }
 
     /**
@@ -44,13 +36,6 @@ export class JWTGenerator {
         });
     }
 
-    /**
-     * Get JWT signing key
-     */
-    private async getJWTKey(): Promise<any> {
-        // Convert secret to Uint8Array for jose library
-        return new TextEncoder().encode(this.jwtSecret);
-    }
 }
 
 /**


### PR DESCRIPTION
- Replace jose library with jsonwebtoken for better Node.js compatibility
- Fix 'crypto is not defined' error in production environment
- Update all JWT operations across the codebase:
  * auth.middleware.ts - JWT verification using jwt.verify()
  * message-handler.ts - JWT signing using jwt.sign()
  * jwt-generator.ts - Token generation using jwt.sign()
  * api.controller.ts - API JWT creation using jwt.sign()
  * generate-token.js - Script token generation using jwt.sign()

- Remove dependency on jose-import utility
- Use jsonwebtoken library which is already in dependencies
- Ensure WA_JWT_SECRET from environment is used consistently
- Maintain HS256 algorithm for JWT signing and verification

This resolves the production deployment error:
ReferenceError: crypto is not defined at jose library

All JWT authentication now works reliably in both local and production environments without Web Crypto API dependencies.