### PR TITLE
Fix ESM compatibility issue with uuid library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "qrcode-terminal": "^0.12.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "uuid": "^13.0.0",
         "whatsapp-web.js": "1.34.1",
         "wwebjs-mongo": "^1.1.0"
       },
@@ -3926,19 +3925,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7158,11 +7144,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-    },
-    "uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "qrcode-terminal": "^0.12.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "uuid": "^13.0.0",
     "whatsapp-web.js": "1.34.1",
     "wwebjs-mongo": "^1.1.0"
   },

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import fs from 'fs';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 import FormData from 'form-data';
 
 export class MessageHandler {
@@ -47,7 +47,7 @@ export class MessageHandler {
 
             // Generate unique filename with proper extension
             const fileExtension = this.getFileExtensionFromMimeType(media.mimetype);
-            const filename = `${uuidv4()}${fileExtension}`;
+            const filename = `${crypto.randomUUID()}${fileExtension}`;
             const filePath = path.join(this.tempDir, filename);
 
             // Save media to temporary file


### PR DESCRIPTION
- Replace uuid library with Node.js built-in crypto.randomUUID()
- Remove uuid dependency from package.json
- Fix ERR_REQUIRE_ESM error in production deployment
- crypto.randomUUID() is available in Node.js 14.17.0+ and works in CommonJS
- Test confirms UUID generation works correctly
- Server starts without ESM compatibility errors