### PR TITLE
Fix Railway auto-restart issue with multiple restart methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ const env: Environment = {
     AI_AGENT: process.env.AI_AGENT || 'FW',
     UPLOAD_USER_ID: process.env.UPLOAD_USER_ID || undefined,
     UPLOAD_AUTH_TOKEN: process.env.UPLOAD_AUTH_TOKEN || undefined,
-    AUTO_RESTART_CRON: process.env.AUTO_RESTART_CRON || undefined
+    AUTO_RESTART_CRON: process.env.AUTO_RESTART_CRON || undefined,
+    AUTO_RESTART_METHOD: process.env.AUTO_RESTART_METHOD || undefined
 };
 
 // Validate required environment variables

--- a/src/services/auto-restart.service.ts
+++ b/src/services/auto-restart.service.ts
@@ -60,8 +60,25 @@ export class AutoRestartService {
             
             console.log('🔄 Graceful shutdown completed. Process will exit for restart.');
             
-            // Exit the process (Docker/PM2 will restart it)
-            process.exit(0);
+            // Give Railway a moment to detect the shutdown
+            setTimeout(() => {
+                console.log('🔄 Exiting process to trigger Railway restart...');
+                
+                // Try different restart methods for Railway
+                const restartMethod = this.env.AUTO_RESTART_METHOD || 'exit';
+                
+                if (restartMethod === 'kill') {
+                    console.log('🔄 Using process.kill() method...');
+                    process.kill(process.pid, 'SIGTERM');
+                } else if (restartMethod === 'crash') {
+                    console.log('🔄 Using crash method...');
+                    throw new Error('Auto-restart triggered - forcing crash');
+                } else {
+                    console.log('🔄 Using process.exit(1) method...');
+                    // Exit with non-zero code to trigger Railway restart
+                    process.exit(1);
+                }
+            }, 1000);
             
         } catch (error) {
             console.error('❌ Error during auto-restart:', error);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Environment {
   UPLOAD_USER_ID?: string | undefined;
   UPLOAD_AUTH_TOKEN?: string | undefined;
   AUTO_RESTART_CRON?: string | undefined;
+  AUTO_RESTART_METHOD?: string | undefined;
 }
 
 // WhatsApp Service Configuration interface


### PR DESCRIPTION
🔧 Railway Restart Fix:

1. **Changed exit code from 0 to 1**:
   - Railway expects non-zero exit codes to trigger restart
   - process.exit(0) was causing Railway to think the shutdown was successful

2. **Added multiple restart methods**:
   - AUTO_RESTART_METHOD environment variable for flexibility
   - 'exit': process.exit(1) - standard non-zero exit
   - 'kill': process.kill(pid, 'SIGTERM') - signal-based restart
   - 'crash': throw Error - force crash restart

3. **Added delay before exit**:
   - 1-second delay to ensure Railway detects the shutdown
   - Better logging for debugging restart process

4. **Enhanced logging**:
   - Clear indication of which restart method is being used
   - Better debugging information for Railway deployment

📋 Usage for Railway:
- AUTO_RESTART_CRON='0 2 * * *' (daily at 2 AM)
- AUTO_RESTART_METHOD='exit' (default, recommended for Railway)

✅ Should now properly trigger Railway container restart ✅ Maintains graceful shutdown before restart
✅ Multiple fallback methods for different deployment scenarios